### PR TITLE
Convert updatedAt to NSDate

### DIFF
--- a/iOSSDK/SQMessage.m
+++ b/iOSSDK/SQMessage.m
@@ -37,6 +37,8 @@
 				 _user = [[SQUser alloc] initObjectWithDictionary:incomingObject];
 			 else if ([key isEqualToString:@"createdAt"])
 				 _createdAt = [SQObject dateWithString:incomingObject];
+			 else if ([key isEqualToString:@"updatedAt"])
+				 _updatedAt = [SQObject dateWithString:incomingObject];
 			 else
 				 [object setValue:incomingObject forKey:key];
 		 }


### PR DESCRIPTION
Fixes a bug where the updatedAt is stored as an NSString and not an NSDate.
